### PR TITLE
Add systemd-network user and group to initramfs

### DIFF
--- a/netconf_install
+++ b/netconf_install
@@ -17,6 +17,8 @@ build ()
       add_systemd_unit "systemd-networkd.socket"
       systemctl --root "$BUILDROOT" enable systemd-networkd.service
       systemctl --root "$BUILDROOT" enable systemd-networkd.socket
+      getent passwd systemd-network >>"$BUILDROOT/etc/passwd"
+      getent group systemd-network >>"$BUILDROOT/etc/group"
       add_dir "/etc/systemd/network"
       ls /etc/systemd/network/*.initramfs > /dev/null 2>&1
       if [ $? -ne 0 ]; then


### PR DESCRIPTION
Currently, systemd-networkd service fails to start with the following error:
```
systemd-networkd.service: Failed to determine user credentials: No such process
systemd-networkd.service: Failed at step USER spawning /usr/lib/systemd/systemd-networkd: No such process
systemd-networkd.service: Main process exited, code=exited, status=217/USER
systemd-networkd.service: Failed with result 'exit-code'.
```

Adding the systemd-network user to initramfs resolves the issue.